### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M7</version>
+				<configuration>
+          				<skipTests>true</skipTests>
+        			</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
Disable surefire tests by default for Maven CI on GitHub. Would surely fail without external tool dependencies (e.g. exiftool) installed.